### PR TITLE
⚡ Bolt: Preload LCP Image & Preconnect Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,13 @@
   <link href="assets/img/favicon.png" rel="icon">
   <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
 
+  <!-- Preload LCP Image -->
+  <!-- The #hero section background image is the Largest Contentful Paint (LCP) element -->
+  <link rel="preload" href="assets/img/hero-bg.jpg" as="image">
+
   <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
 
   <!-- Vendor CSS Files -->

--- a/portfolio-details.html
+++ b/portfolio-details.html
@@ -13,6 +13,8 @@
   <link rel="apple-touch-icon" href="assets/img/apple-touch-icon.png">
 
   <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i">
 
   <!-- Vendor CSS Files -->


### PR DESCRIPTION
💡 What: Added `<link rel="preload">` for the hero background image (`assets/img/hero-bg.jpg`) in `index.html`. Added `<link rel="preconnect">` for Google Fonts (`fonts.googleapis.com` and `fonts.gstatic.com` with `crossorigin`) in both `index.html` and `portfolio-details.html`. Added explanatory comments.

🎯 Why: The hero background image is the Largest Contentful Paint (LCP) element on the index page. Preloading it ensures the browser fetches it as quickly as possible, significantly improving the LCP metric. Preconnecting to the Google Fonts domains establishes the connection (DNS, TCP, TLS) early, which speeds up font downloading and reduces time to render text.

📊 Impact: Reduces Largest Contentful Paint (LCP) time and speeds up text rendering across both pages by removing connection latency for external font domains.

🔬 Measurement: Verify using Lighthouse (or PageSpeed Insights). The "Preload Largest Contentful Paint image" recommendation should be resolved, and the time spent connecting to third-party domains should be reduced.

---
*PR created automatically by Jules for task [5917729326849830709](https://jules.google.com/task/5917729326849830709) started by @Mitesh411*