### PR TITLE
⚡ Bolt: [performance improvement] Preload LCP and Preconnect Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,12 @@
   <link href="assets/img/favicon.png" rel="icon">
   <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
 
-  <!-- Google Fonts -->
+  <!-- LCP Optimization: Preload the hero background image -->
+  <link rel="preload" as="image" href="assets/img/hero-bg.jpg">
+
+  <!-- Google Fonts Optimization: Preconnect to font domains -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
 
   <!-- Vendor CSS Files -->

--- a/portfolio-details.html
+++ b/portfolio-details.html
@@ -12,7 +12,9 @@
   <link rel="icon" href="assets/img/favicon.png">
   <link rel="apple-touch-icon" href="assets/img/apple-touch-icon.png">
 
-  <!-- Google Fonts -->
+  <!-- Google Fonts Optimization: Preconnect to font domains -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i">
 
   <!-- Vendor CSS Files -->


### PR DESCRIPTION
💡 What: 
Added `<link rel="preload">` for the hero background image in `index.html` and `<link rel="preconnect">` for Google Fonts domains in both `index.html` and `portfolio-details.html`. Added descriptive comments to explain the optimizations.

🎯 Why: 
The background image in the `#hero` section is the Largest Contentful Paint (LCP) element on the index page, but it is defined in CSS, meaning the browser discovers it late in the loading process. Preloading it tells the browser to fetch it immediately. Additionally, preconnecting to the Google Fonts domains saves time by establishing network connections (DNS, TCP, TLS) before the browser actually requests the CSS and font files.

📊 Impact: 
Measurably faster LCP (Largest Contentful Paint) for the main page and faster font loading (reducing Flash of Unstyled Text / invisible text duration) across both pages.

🔬 Measurement: 
Load the pages with Chrome DevTools Network tab open (disable cache). You should see the `hero-bg.jpg` requested much earlier in the waterfall, and the connections to `fonts.googleapis.com` / `fonts.gstatic.com` established sooner. Run a Lighthouse performance audit to see an improved LCP score.

---
*PR created automatically by Jules for task [13032337406057253204](https://jules.google.com/task/13032337406057253204) started by @Mitesh411*