### PR TITLE
🔒 [security fix] Information Disclosure in Mailer Error

### DIFF
--- a/forms/contact.php
+++ b/forms/contact.php
@@ -166,9 +166,8 @@ try {
     // --- Send Error JSON Response ---
     header('Content-Type: application/json');
     http_response_code(500);
-    // For extra security, you might not want to show the detailed error to the user.
-    // But for debugging, it's very helpful.
-    echo json_encode(['success' => false, 'message' => "Message could not be sent. Mailer Error: {$mail->ErrorInfo}"]);
+    // Generic error message to prevent information disclosure.
+    echo json_encode(['success' => false, 'message' => 'Message could not be sent. Please try again later.']);
 }
 
 ?>


### PR DESCRIPTION
### 🎯 **What:** The vulnerability fixed
This PR addresses an Information Disclosure vulnerability in the `forms/contact.php` script where internal mailer error details were exposed to the client.

### ⚠️ **Risk:** The potential impact if left unfixed
Exposing `$mail->ErrorInfo` can reveal sensitive server information, including:
- SMTP server addresses
- Internal IP addresses or hostnames
- Authentication issues that might hint at credentials or network configurations
This information can be used by an attacker to gain a better understanding of the infrastructure and potentially launch further attacks.

### 🛡️ **Solution:** How the fix addresses the vulnerability
The vulnerable code block in the `catch` statement of `forms/contact.php` has been updated to return a generic error message instead of the specific error details from PHPMailer.

**Changes:**
- Replaced `{$mail->ErrorInfo}` with a static, generic message: `'Message could not be sent. Please try again later.'`
- Removed comments that suggested showing detailed errors for debugging in production.

**Verification:**
- Verified with a mock PHP test script that the response is now generic.
- Checked for PHP syntax errors using `php -l`.

---
*PR created automatically by Jules for task [12198032606703632791](https://jules.google.com/task/12198032606703632791) started by @Mitesh411*